### PR TITLE
Run build+test when a pull request is opened

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,6 +7,9 @@ on:
       - 'master'
     tags:
       - '*'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   build-firmware:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,13 @@
 name: SuperFW test
 run-name: Build and run SuperFW tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   run-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.gcda
 *.gcno
 *.info
+*.bin
+coverage/


### PR DESCRIPTION
Currently, builds and tests are only run when pushed directly to main. This change ensures that it is also run when a pull request is opened.

Tip: once merged, create a branch ruleset with "Require status checks to pass" enabled