### PR TITLE
Add setting menu to toggle showing hidden files

### DIFF
--- a/res/messages.py
+++ b/res/messages.py
@@ -69,11 +69,12 @@ en_strings = {
 
   "MSG_DEFS_PATCH":  "Patching",
 
-  "MSG_UIS_THEME": "Theme color",
-  "MSG_UIS_LANG":  "Language",
-  "MSG_UIS_RECNT": "Recent ROMs",
-  "MSG_UIS_ANSPD": "Text speed",
-  "MSG_UIS_SAVE":  "Save to SD card",
+  "MSG_UIS_THEME":      "Theme color",
+  "MSG_UIS_LANG":       "Language",
+  "MSG_UIS_RECNT":      "Recent ROMs",
+  "MSG_UIS_SHOWHIDDEN": "Show Hidden files",
+  "MSG_UIS_ANSPD":      "Text speed",
+  "MSG_UIS_SAVE":       "Save to SD card",
 
   "MSG_UIS_SPD0":  "< Very slow >",
   "MSG_UIS_SPD1":  "< Slow >",

--- a/src/menu.c
+++ b/src/menu.c
@@ -333,6 +333,7 @@ _Static_assert (sizeof(t_sdram_state) <= 15*1024*1024, "scratch SDRAM doesn't ex
 typedef struct {
   unsigned char name;
   void (*render)(char* buf, int buflen);
+  void (*on_change)(void);
   
   uint32_t *from_bool;
 
@@ -2413,6 +2414,9 @@ void menu_keypress(unsigned newkeys) {
           } else if (item->from_int != NULL && *item->from_int > 0) {
             *item->from_int = *item->from_int - 1;
           }
+          if (item->on_change) {
+            item->on_change();
+          }
         }
         if (newkeys & KEY_BUTTRIGHT) {
           const UiMenuItem *item = &ui_settings_items[smenu.uiset.selector];
@@ -2420,6 +2424,9 @@ void menu_keypress(unsigned newkeys) {
             *item->from_bool ^= 1;
           } else if (item->from_int != NULL) {
             *item->from_int = MIN(item->from_int_max - 1, *item->from_int + 1);
+          }
+          if (item->on_change) {
+            item->on_change();
           }
         }
       }

--- a/src/menu.c
+++ b/src/menu.c
@@ -1086,6 +1086,13 @@ static void browser_reload() {
     if (f_readdir(&d, &info) != FR_OK || !info.fname[0])
       break;
 
+    if (!show_hidden_files) {
+      if (info.fname[0] == '.') // Skip dot files
+        continue;
+      if (info.fattrib & AM_HID) // Skip hidden files
+        continue;
+    }
+
     if (fcount >= BROWSER_MAXFN_CNT)
       break;
 
@@ -1664,6 +1671,7 @@ static const UiMenuItem ui_settings_items[] = {
   { .name = MSG_UIS_THEME, .render = render_ui_setting_theme, .from_int = &menu_theme, .from_int_max = THEME_COUNT },
   { .name = MSG_UIS_LANG, .render = render_ui_setting_lang, .from_int = &lang_id, .from_int_max = LANG_COUNT },
   { .name = MSG_UIS_RECNT, .from_bool = &recent_menu },
+  { .name = MSG_UIS_SHOWHIDDEN, .from_bool = &show_hidden_files, .on_change = browser_reload },
   { .name = MSG_UIS_ANSPD, .from_int = &anim_speed, .from_int_offset = MSG_UIS_SPD0, .from_int_max = animspd_cnt },
 };
 #define UI_SETTINGS_ITEMS_COUNT (sizeof(ui_settings_items)/sizeof(UiMenuItem))

--- a/src/menu.c
+++ b/src/menu.c
@@ -1667,8 +1667,24 @@ void render_ui_setting_lang(char *buf, int buflen) {
   npf_snprintf(buf, buflen, "< %s >", msgs[lang_id][MSG_LANG_NAME]);
 }
 
+void reload_theme() {
+  // Palette 0..15 contains the main menu template colors
+  MEM_PALETTE[FG_COLOR] = themes[menu_theme].fg_color;
+  MEM_PALETTE[BG_COLOR] = themes[menu_theme].bg_color;
+  MEM_PALETTE[FT_COLOR] = themes[menu_theme].ft_color;
+  MEM_PALETTE[HI_COLOR] = themes[menu_theme].hi_color;
+  // In-game menu palette
+  MEM_PALETTE[INGMENU_PAL_FG] = themes[menu_theme].fg_color;
+  MEM_PALETTE[INGMENU_PAL_BG] = themes[menu_theme].bg_color;
+  MEM_PALETTE[INGMENU_PAL_HI] = themes[menu_theme].ft_color;
+  MEM_PALETTE[INGMENU_PAL_SH] = themes[menu_theme].sh_color;
+
+  // Palette entries for icons and other objects
+  MEM_PALETTE[256 + SEL_COLOR] = themes[menu_theme].hi_blend;
+}
+
 static const UiMenuItem ui_settings_items[] = {
-  { .name = MSG_UIS_THEME, .render = render_ui_setting_theme, .from_int = &menu_theme, .from_int_max = THEME_COUNT },
+  { .name = MSG_UIS_THEME, .render = render_ui_setting_theme, .from_int = &menu_theme, .from_int_max = THEME_COUNT, .on_change = reload_theme },
   { .name = MSG_UIS_LANG, .render = render_ui_setting_lang, .from_int = &lang_id, .from_int_max = LANG_COUNT },
   { .name = MSG_UIS_RECNT, .from_bool = &recent_menu },
   { .name = MSG_UIS_SHOWHIDDEN, .from_bool = &show_hidden_files, .on_change = browser_reload },
@@ -1759,22 +1775,6 @@ void render_tools(volatile uint8_t *frame) {
   }
 }
 
-void reload_theme(unsigned thnum) {
-  // Palette 0..15 contains the main menu template colors
-  MEM_PALETTE[FG_COLOR] = themes[thnum].fg_color;
-  MEM_PALETTE[BG_COLOR] = themes[thnum].bg_color;
-  MEM_PALETTE[FT_COLOR] = themes[thnum].ft_color;
-  MEM_PALETTE[HI_COLOR] = themes[thnum].hi_color;
-  // In-game menu palette
-  MEM_PALETTE[INGMENU_PAL_FG] = themes[thnum].fg_color;
-  MEM_PALETTE[INGMENU_PAL_BG] = themes[thnum].bg_color;
-  MEM_PALETTE[INGMENU_PAL_HI] = themes[thnum].ft_color;
-  MEM_PALETTE[INGMENU_PAL_SH] = themes[thnum].sh_color;
-
-  // Palette entries for icons and other objects
-  MEM_PALETTE[256 + SEL_COLOR] = themes[thnum].hi_blend;
-}
-
 // Renders the menu. Arg0 represents the frame count difference with the
 // previous rendered frame (for animations and similar stuff).
 void menu_render(unsigned fcnt) {
@@ -1862,7 +1862,7 @@ void menu_init(int sram_testres) {
   // Load recent ROMs (we could disable this for speed)
   recent_reload();
 
-  reload_theme(menu_theme);
+  reload_theme();
 
   smenu.menu_tab = (recent_menu && smenu.recent.maxentries) ? MENUTAB_RECENT : MENUTAB_ROMBROWSE;
 
@@ -2447,7 +2447,6 @@ void menu_keypress(unsigned newkeys) {
           spop.alert_msg = msgs[lang_id][MSG_ERR_SETSAVE];
       }
 
-      reload_theme(menu_theme);
       break;
 
     case MENUTAB_TOOLS:

--- a/src/settings.c
+++ b/src/settings.c
@@ -56,6 +56,7 @@ const uint8_t animspd_lut[] = {
 uint32_t menu_theme = 0;
 uint32_t lang_id = 0;
 uint32_t recent_menu = 1;
+uint32_t show_hidden_files = 1;
 uint32_t anim_speed = animspd_cnt / 2;
 
 // Default settings
@@ -99,8 +100,9 @@ bool save_ui_settings() {
     "menu_theme=%lu\n"
     "langcode=%c%c\n"
     "recent_menu=%lu\n"
+    "show_hidden_files=%lu\n"
     "anim_speed=%lu\n",
-    menu_theme, (lc & 0xFF), (lc >> 8), recent_menu, anim_speed);
+    menu_theme, (lc & 0xFF), (lc >> 8), recent_menu, show_hidden_files, anim_speed);
 
   UINT wrbytes;
   FRESULT res = f_write(&fd, buf, strlen(buf), &wrbytes);
@@ -199,6 +201,8 @@ static void parse_ui_settings(void *usr, const char *var, const char *value) {
     menu_theme = valu;
   else if (!strcmp(var, "recent_menu"))
     recent_menu = valu;
+  else if (!strcmp(var, "show_hidden_files"))
+    show_hidden_files = valu;
   else if (!strcmp(var, "anim_speed"))
     anim_speed = valu;
   else if (!strcmp(var, "langcode")) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -42,6 +42,7 @@ enum { StateSavestateDir = 0, StateRomName = 1, StateDirCNT = 2 };
 extern uint32_t menu_theme;
 extern uint32_t lang_id;
 extern uint32_t recent_menu;
+extern uint32_t show_hidden_files;
 extern uint32_t anim_speed;
 
 // Defaults/Settings


### PR DESCRIPTION
This adds a setting to toggle whether hidden files (both FAT hidden files and dot files) should be shown in the file browser or not.

It also refactors the setting menu a little so new entries can be added more quickly.