### PR TITLE
Add cover-art / title-screen previews in the ROM/recent/NOR browsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ INFILES=src/gba_ewram_crt0.S \
         src/patcher.c \
         src/patches.S \
         src/menu.c \
+        src/coverart.c \
         src/cheats.c \
         src/flash.c \
         src/sha256.c \

--- a/src/coverart.c
+++ b/src/coverart.c
@@ -1,0 +1,161 @@
+/*
+ * Cover-art / title-screen preview for the ROM browser.  See coverart.h.
+ *
+ * Reads "/IMGS/{c0}/{c1}/{CODE}.bmp" (120x80, 16bpp X1R5G5B5) directly off the SD
+ * card, maps each pixel to a fixed 6x6x6 palette cube (MEM_PALETTE[20..235]) and
+ * caches the resulting 8bpp image for fast per-frame blits.
+ */
+#include <string.h>
+#include <stdbool.h>
+
+#include "gbahw.h"
+#include "fatfs/ff.h"
+#include "common.h"
+#include "nanoprintf.h"
+#include "coverart.h"
+
+#define COVER_DIR  "/IMGS"
+
+// Big buffers go in EWRAM (.sbss); the default .bss lives in scarce IWRAM.
+#define EWRAM_BSS  __attribute__((section(".sbss")))
+
+static EWRAM_BSS __attribute__((aligned(4))) uint8_t cover_pix[COVER_W * COVER_H];
+static EWRAM_BSS char cover_key[512];     // ROM path the current state belongs to
+static bool     cover_have;               // a valid cover is loaded (.bss/IWRAM -> zeroed)
+static uint16_t cube_pal[CUBE_NCOLORS];   // the fixed color cube (GBA BGR555)
+static bool     cube_built;
+
+// Build the 6x6x6 cube once. Each channel uses 6 evenly spread 5-bit levels.
+static void build_cube(void) {
+  static const uint8_t lvl[6] = { 0, 6, 12, 19, 25, 31 };
+  for (unsigned r = 0; r < 6; r++)
+    for (unsigned g = 0; g < 6; g++)
+      for (unsigned b = 0; b < 6; b++)
+        cube_pal[r * 36 + g * 6 + b] = (lvl[b] << 10) | (lvl[g] << 5) | lvl[r];
+  cube_built = true;
+}
+
+// Map a BMP 16-bit pixel to its nearest cube index (already biased by base).
+// The EZ-Flash-Omega pack stores pixels GBA-native (X1B5G5R5): red is the LOW
+// 5 bits, blue the high 5 bits (not the standard X1R5G5B5 BMP layout).
+static inline uint8_t rgb555_to_cube(unsigned v) {
+  unsigned r = v & 0x1F, g = (v >> 5) & 0x1F, b = (v >> 10) & 0x1F;
+  return CUBE_PAL_BASE + (((r * 6) >> 5) * 36 + ((g * 6) >> 5) * 6 + ((b * 6) >> 5));
+}
+
+static bool gcode_is_alnum(const uint8_t *c) {
+  for (unsigned i = 0; i < 4; i++) {
+    uint8_t ch = c[i];
+    if (!((ch >= '0' && ch <= '9') ||
+          (ch >= 'A' && ch <= 'Z') ||
+          (ch >= 'a' && ch <= 'z')))
+      return false;
+  }
+  return true;
+}
+
+static bool load_cover_file(const uint8_t gcode[4]) {
+  char path[64];
+  npf_snprintf(path, sizeof(path), "%s/%c/%c/%c%c%c%c.bmp",
+               COVER_DIR, gcode[0], gcode[1],
+               gcode[0], gcode[1], gcode[2], gcode[3]);
+
+  FIL fd;
+  if (FR_OK != f_open(&fd, path, FA_READ))
+    return false;
+
+  bool ok = false;
+  UINT rd;
+  uint8_t hdr[54];
+
+  if (FR_OK == f_read(&fd, hdr, sizeof(hdr), &rd) && rd == sizeof(hdr) &&
+      hdr[0] == 'B' && hdr[1] == 'M') {
+    uint32_t dataoff = hdr[10] | (hdr[11] << 8) | (hdr[12] << 16) | (hdr[13] << 24);
+    int32_t  width   = hdr[18] | (hdr[19] << 8) | (hdr[20] << 16) | (hdr[21] << 24);
+    int32_t  rawh    = hdr[22] | (hdr[23] << 8) | (hdr[24] << 16) | (hdr[25] << 24);
+    unsigned bpp     = hdr[28] | (hdr[29] << 8);
+    bool topdown = rawh < 0;
+    int32_t height = topdown ? -rawh : rawh;
+
+    if (bpp == 16 && width > 0 && width <= COVER_W &&
+        height > 0 && height <= COVER_H && FR_OK == f_lseek(&fd, dataoff)) {
+      if (!cube_built)
+        build_cube();
+
+      // Pad letterbox (smaller images) with cube index 0 (= black).
+      memset(cover_pix, CUBE_PAL_BASE, sizeof(cover_pix));
+
+      unsigned rowbytes = ((unsigned)width * 2 + 3) & ~3u;   // 4-byte aligned rows
+      uint8_t rowbuf[COVER_W * 2];
+      ok = true;
+      for (int sy = 0; sy < height; sy++) {
+        if (FR_OK != f_read(&fd, rowbuf, rowbytes, &rd) || rd != rowbytes) {
+          ok = false;
+          break;
+        }
+        unsigned dy = topdown ? (unsigned)sy : (unsigned)(height - 1 - sy);
+        uint8_t *dst = &cover_pix[dy * COVER_W];
+        for (int x = 0; x < width; x++)
+          dst[x] = rgb555_to_cube(rowbuf[x * 2] | (rowbuf[x * 2 + 1] << 8));
+      }
+
+      if (ok)
+        dma_memcpy16(&MEM_PALETTE[CUBE_PAL_BASE], cube_pal, CUBE_NCOLORS);
+    }
+  }
+
+  f_close(&fd);
+  return ok;
+}
+
+void coverart_invalidate(void) {
+  cover_key[0] = 0;
+  cover_have = false;
+}
+
+void coverart_update(const char *rom_fullpath, uint32_t filesize, bool is_gba) {
+  // No-op while the selection hasn't moved (avoids re-reading the SD card).
+  if (0 == strncmp(cover_key, rom_fullpath, sizeof(cover_key) - 1))
+    return;
+
+  strncpy(cover_key, rom_fullpath, sizeof(cover_key) - 1);
+  cover_key[sizeof(cover_key) - 1] = 0;
+  cover_have = false;
+
+  if (!is_gba)
+    return;
+
+  t_rom_header romh;
+  if (0 != preload_gba_rom(rom_fullpath, filesize, &romh))
+    return;
+
+  if (gcode_is_alnum(romh.gcode))
+    cover_have = load_cover_file(romh.gcode);
+}
+
+void coverart_update_gcode(const char *cachekey, const uint8_t gcode[4]) {
+  if (0 == strncmp(cover_key, cachekey, sizeof(cover_key) - 1))
+    return;
+
+  strncpy(cover_key, cachekey, sizeof(cover_key) - 1);
+  cover_key[sizeof(cover_key) - 1] = 0;
+  cover_have = false;
+
+  if (gcode_is_alnum(gcode))
+    cover_have = load_cover_file(gcode);
+}
+
+bool coverart_available(void) {
+  return cover_have;
+}
+
+void coverart_draw(volatile uint8_t *frame) {
+  if (!cover_have)
+    return;
+  // Re-assert our palette every frame: the logo (info tab) shares the
+  // MEM_PALETTE[20..235] range and may have overwritten the cube.
+  dma_memcpy16(&MEM_PALETTE[CUBE_PAL_BASE], cube_pal, CUBE_NCOLORS);
+  for (unsigned r = 0; r < COVER_H; r++)
+    dma_memcpy16(&frame[(COVER_PANE_Y + r) * 240 + COVER_PANE_X],
+                 &cover_pix[r * COVER_W], COVER_W / 2);
+}

--- a/src/coverart.h
+++ b/src/coverart.h
@@ -1,0 +1,49 @@
+/*
+ * Cover-art / title-screen preview for the ROM browser.
+ *
+ * Reads EZ-Flash-Omega style thumbnails directly from the SD card:
+ *   /IMGS/{c0}/{c1}/{CODE}.bmp  (120x80, 16bpp X1R5G5B5 BMP, keyed by GBA game code)
+ * Each pixel is mapped on the fly to a fixed 6x6x6 (216 color) palette cube that
+ * lives in the free BG palette indices 20..235, and blitted into a bottom-right
+ * pane of the Mode-4 menu framebuffer (EZ-Flash-Omega style).
+ */
+#ifndef __COVERART_H__
+#define __COVERART_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Native thumbnail size (matches the EZ-Omega .bmp pack).
+#define COVER_W          120
+#define COVER_H          80
+
+// Fixed 6x6x6 color cube, placed in the free BG palette range 20..235
+// (theme=16..19, logo=1..15, IGM=240..244, selector=255 are left untouched).
+#define CUBE_PAL_BASE    20
+#define CUBE_NCOLORS     216
+
+// Bottom-right pane, just above the y=144 footer bar.
+#define COVER_PANE_X     (240 - COVER_W - 2)    // 118
+#define COVER_PANE_Y     (144 - COVER_H - 2)    // 62
+
+// Forget the cached cover (call when the directory listing is rebuilt or the
+// feature is toggled off).
+void coverart_invalidate(void);
+
+// Ensure the cover for the currently selected ROM is loaded. Only touches the
+// SD card when the selection actually changed, so it is cheap to call per frame.
+// Pass is_gba=false (or an empty path) to clear the cover for non-ROM entries.
+void coverart_update(const char *rom_fullpath, uint32_t filesize, bool is_gba);
+
+// Like coverart_update but keyed directly by a stored 4-char game code (no ROM
+// header read) -- used for NOR/flash games. `cachekey` is any stable string
+// unique to the entry; the SD card is only touched when it changes.
+void coverart_update_gcode(const char *cachekey, const uint8_t gcode[4]);
+
+// Whether a cover is currently loaded and should be drawn.
+bool coverart_available(void);
+
+// Blit the loaded cover into the bottom-right pane of `frame`.
+void coverart_draw(volatile uint8_t *frame);
+
+#endif

--- a/src/menu.c
+++ b/src/menu.c
@@ -35,6 +35,7 @@
 #include "flash_mgr.h"
 #include "sha256.h"
 #include "supercard_driver.h"
+#include "coverart.h"
 
 #include "res/icons.h"
 #include "res/logo.h"
@@ -1389,6 +1390,19 @@ static void draw_central_text_wrapped(const char *t, volatile uint8_t *frame, un
 }
 
 void render_recent(volatile uint8_t *frame) {
+  // Load the cover for the highlighted ROM (cheap unless the selection moved).
+  bool cover_on = false;
+  if (!smenu.recent.maxentries)
+    coverart_invalidate();
+  else {
+    t_rentry *sel = &sdr_state->rentries[smenu.recent.selector];
+    const char *selfn = &sel->fpath[sel->fname_offset];
+    unsigned sl = strlen(selfn);
+    bool is_gba = (sl >= 4 && !strcasecmp(&selfn[sl - 4], ".gba"));
+    coverart_update(sel->fpath, 0, is_gba);
+    cover_on = coverart_available();
+  }
+
   // Render the list from memory.
   for (unsigned i = 0; i < RECENT_ROWS; i++) {
     if (smenu.recent.seloff + i >= smenu.recent.maxentries)
@@ -1398,16 +1412,27 @@ void render_recent(volatile uint8_t *frame) {
     char *fn = &e->fpath[e->fname_offset];
     render_icon(2, (i+1)*16, guessicon(fn));
 
+    // Keep rows overlapping the cover pane clear of it.
+    unsigned rowy = (1 + i) * 16;
+    unsigned rmax = (cover_on && rowy + 15 >= COVER_PANE_Y) ? (COVER_PANE_X - 3) : SCREEN_WIDTH;
+
     // Animate the row entries if they are too long!
     if (i == smenu.recent.selector - smenu.recent.seloff)
-      draw_text_ovf_rotate(fn, frame, 20, (1 + i) * 16,
-                           SCREEN_WIDTH - 24, &smenu.anim_state);
+      draw_text_ovf_rotate(fn, frame, 20, rowy, rmax - 24, &smenu.anim_state);
     else
-      draw_text_ovf(fn, frame, 20, (1 + i) * 16, SCREEN_WIDTH - 24);
+      draw_text_ovf(fn, frame, 20, rowy, rmax - 24);
   }
 
-  for (unsigned i = 0; i < 240; i += 16)
-    render_icon_trans(i, (smenu.recent.selector - smenu.recent.seloff + 1)*16, 63);
+  unsigned selrowy = (smenu.recent.selector - smenu.recent.seloff + 1) * 16;
+  unsigned hlright = (cover_on && selrowy + 15 >= COVER_PANE_Y) ? COVER_PANE_X : 240;
+  for (unsigned i = 0; i < hlright; i += 16)
+    render_icon_trans(i, selrowy, 63);
+
+  if (cover_on) {
+    coverart_draw(frame);
+    draw_box_outline(frame, COVER_PANE_X - 1, COVER_PANE_X + COVER_W + 1,
+                     COVER_PANE_Y - 1, COVER_PANE_Y + COVER_H + 1, FG_COLOR);
+  }
 }
 
 #ifdef SUPPORT_NORGAMES
@@ -1415,10 +1440,19 @@ void render_flashbrowser(volatile uint8_t *frame) {
   // Render bar below to show block info
   dma_memset16(&frame[240*144], dup8(FG_COLOR), 240*16/2);
 
+  bool cover_on = false;
+
   // Render the list from memory.
-  if (!smenu.fbrowser.maxentries)
+  if (!smenu.fbrowser.maxentries) {
+    coverart_invalidate();
     draw_central_text(msgs[lang_id][MSG_NOR_EMPTY], frame, SCREEN_WIDTH/2, SCREEN_HEIGHT/2-8);
+  }
   else {
+    // Flash games store their game code, so the cover loads without a file read.
+    t_flash_game_entry *sel = &sdr_state->nordata.games[smenu.fbrowser.selector];
+    coverart_update_gcode(&sel->game_name[sel->bnoffset], (const uint8_t*)&sel->gamecode);
+    cover_on = coverart_available();
+
     for (unsigned i = 0; i < NORGAMES_ROWS; i++) {
       if (smenu.fbrowser.seloff + i >= smenu.fbrowser.maxentries)
         break;
@@ -1426,22 +1460,32 @@ void render_flashbrowser(volatile uint8_t *frame) {
       t_flash_game_entry *e = &sdr_state->nordata.games[smenu.fbrowser.seloff + i];
       render_icon(2, (i+1)*16, ICON_GBACART);
 
-      // Animate the row entries if they are too long!
+      unsigned rowy = (1 + i) * 16;
+      unsigned rmax = (cover_on && rowy + 15 >= COVER_PANE_Y) ? (COVER_PANE_X - 3) : SCREEN_WIDTH;
+
       char szstr[16];
       human_size(szstr, sizeof(szstr), e->numblks * NOR_BLOCK_SIZE);
-      draw_rightj_text(szstr, frame, SCREEN_WIDTH - 2, (1 + i) * 16);
+      draw_rightj_text(szstr, frame, rmax - 2, rowy);
 
       // Animate the row entries if they are too long!
       const char *romname = &e->game_name[e->bnoffset];
       if (i == smenu.fbrowser.selector - smenu.fbrowser.seloff)
-        draw_text_ovf_rotate(romname, frame, 20, (1 + i) * 16,
-                             SCREEN_WIDTH - 26 - font_width(szstr), &smenu.anim_state);
+        draw_text_ovf_rotate(romname, frame, 20, rowy,
+                             rmax - 26 - font_width(szstr), &smenu.anim_state);
       else
-        draw_text_ovf(romname, frame, 20, (1 + i) * 16, SCREEN_WIDTH - 26 - font_width(szstr));
+        draw_text_ovf(romname, frame, 20, rowy, rmax - 26 - font_width(szstr));
     }
 
-    for (unsigned i = 0; i < 240; i += 16)
-      render_icon_trans(i, (smenu.fbrowser.selector - smenu.fbrowser.seloff + 1)*16, 63);
+    unsigned selrowy = (smenu.fbrowser.selector - smenu.fbrowser.seloff + 1) * 16;
+    unsigned hlright = (cover_on && selrowy + 15 >= COVER_PANE_Y) ? COVER_PANE_X : 240;
+    for (unsigned i = 0; i < hlright; i += 16)
+      render_icon_trans(i, selrowy, 63);
+  }
+
+  if (cover_on) {
+    coverart_draw(frame);
+    draw_box_outline(frame, COVER_PANE_X - 1, COVER_PANE_X + COVER_W + 1,
+                     COVER_PANE_Y - 1, COVER_PANE_Y + COVER_H + 1, FG_COLOR);
   }
 
   char tmp[32], tmp1[32], tmp2[32];
@@ -1459,9 +1503,26 @@ void render_browser(volatile uint8_t *frame) {
   // Render bar below to show path URI
   dma_memset16(&frame[240*144], dup8(FG_COLOR), 240*16/2);
 
-  if (!smenu.browser.dispentries)
+  bool cover_on = false;
+
+  if (!smenu.browser.dispentries) {
+    coverart_invalidate();
     draw_central_text(msgs[lang_id][MSG_BROW_EMPTY], frame, SCREEN_WIDTH/2, SCREEN_HEIGHT/2-8);
+  }
   else {
+    // Load the cover/title-screen for the highlighted ROM.
+    t_centry *sel = sdr_state->fileorder[smenu.browser.selector];
+    if (sel->attr & AM_DIR)
+      coverart_update("", 0, false);
+    else {
+      char fpath[512];
+      npf_snprintf(fpath, sizeof(fpath), "%s%s", smenu.browser.cpath, sel->fname);
+      unsigned sl = strlen(sel->fname);
+      bool is_gba = (sl >= 4 && !strcasecmp(&sel->fname[sl - 4], ".gba"));
+      coverart_update(fpath, sel->filesize, is_gba);
+    }
+    cover_on = coverart_available();
+
     for (unsigned i = 0; i < BROWSER_ROWS; i++) {
       if (smenu.browser.seloff + i >= smenu.browser.dispentries)
         break;
@@ -1474,20 +1535,32 @@ void render_browser(volatile uint8_t *frame) {
 
       render_icon(2, (i+1)*16, iconidx);
 
+      // Keep rows overlapping the cover pane clear of it.
+      unsigned rowy = (1 + i) * 16;
+      unsigned rmax = (cover_on && rowy + 15 >= COVER_PANE_Y) ? (COVER_PANE_X - 3) : SCREEN_WIDTH;
+
       char szstr[16];
       human_size(szstr, sizeof(szstr), e->filesize);
-      draw_rightj_text(szstr, frame, SCREEN_WIDTH - 2, (1 + i) * 16);
+      draw_rightj_text(szstr, frame, rmax - 2, rowy);
 
       // Animate the row entries if they are too long!
       if (i == smenu.browser.selector - smenu.browser.seloff)
-        draw_text_ovf_rotate(e->fname, frame, 20, (1 + i) * 16,
-                             SCREEN_WIDTH - 26 - font_width(szstr), &smenu.anim_state);
+        draw_text_ovf_rotate(e->fname, frame, 20, rowy,
+                             rmax - 26 - font_width(szstr), &smenu.anim_state);
       else
-        draw_text_ovf(e->fname, frame, 20, (1 + i) * 16, SCREEN_WIDTH - 26 - font_width(szstr));
+        draw_text_ovf(e->fname, frame, 20, rowy, rmax - 26 - font_width(szstr));
     }
 
-    for (unsigned i = 0; i < 240; i += 16)
-      render_icon_trans(i, (smenu.browser.selector - smenu.browser.seloff + 1)*16, 63);
+    unsigned selrowy = (smenu.browser.selector - smenu.browser.seloff + 1) * 16;
+    unsigned hlright = (cover_on && selrowy + 15 >= COVER_PANE_Y) ? COVER_PANE_X : 240;
+    for (unsigned i = 0; i < hlright; i += 16)
+      render_icon_trans(i, selrowy, 63);
+  }
+
+  if (cover_on) {
+    coverart_draw(frame);
+    draw_box_outline(frame, COVER_PANE_X - 1, COVER_PANE_X + COVER_W + 1,
+                     COVER_PANE_Y - 1, COVER_PANE_Y + COVER_H + 1, FG_COLOR);
   }
 
   // Draw path, cut left part if necessary.


### PR DESCRIPTION
Shows a per-game image in the bottom-right of the browser, recent list and NOR-games list. Reads EZ-Flash-Omega style thumbnail packs straight from the SD card: /IMGS/{c0}/{c1}/{CODE}.bmp (120x80 16-bit BMP keyed by the 4-char GBA game code). Each pixel is mapped on the fly to a 6x6x6 (216-color) cube placed in the free BG palette range (indices 20..235), so no offline conversion or extra palette bookkeeping is needed. The list rows overlapping the pane are clipped so text stays clear of the image.

Self-contained in coverart.{c,h}; the browser render functions just call coverart_update()/coverart_update_gcode()/coverart_draw(). Degrades gracefully (no pane) when no matching image exists on the card.