### PR TITLE
Adding dotfiles to hidden detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 *.gcno
 *.info
 *.i
+*.fw
+src/menu_messages.h
+src/messages_data.h

--- a/src/menu.c
+++ b/src/menu.c
@@ -1091,7 +1091,7 @@ static void browser_reload_filter() {
   // of memory, we use a list of pointers.
   unsigned fcount = 0;
   for (unsigned i = 0; i < smenu.browser.maxentries; i++) {
-    if ((sdr_state->fentries[i].attr & AM_HID) && hide_hidden)
+    if (((sdr_state->fentries[i].attr & AM_HID) || sdr_state->fentries[i].fname[0] == '.') && hide_hidden)
       continue;
 
     sdr_state->fileorder[fcount++] = &sdr_state->fentries[i];


### PR DESCRIPTION
## Changes
### menu.c
- **browser_reload_filter** Updated so files that dotfiles, files that start with a period (.), are considered hidden files. This is a common convention on *NIX systems rather than using a file attribute.